### PR TITLE
fix building package #85ztr57wy

### DIFF
--- a/deps.repos
+++ b/deps.repos
@@ -6,8 +6,8 @@ repositories:
   ./../perception_pcl:
     type: git
     url: https://github.com/ros-perception/perception_pcl.git
-    version: foxy-devel
+    version: ros2
   ./../pcl_msgs:
     type: git
     url: https://github.com/ros-perception/pcl_msgs.git
-    version: ros2
+    version: 1.0.0

--- a/include/octomap_server2/conversions.h
+++ b/include/octomap_server2/conversions.h
@@ -47,7 +47,7 @@
 #include <geometry_msgs/msg/quaternion.hpp>
 
 #include <tf2/transform_datatypes.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 namespace octomap {
     /**

--- a/include/octomap_server2/octomap_server.hpp
+++ b/include/octomap_server2/octomap_server.hpp
@@ -38,7 +38,7 @@
 #include <tf2_ros/create_timer_ros.h>
 #include <tf2_ros/message_filter.h>
 
-#include <conversions.h>
+#include <octomap_msgs/conversions.h>
 #include <octomap_msgs/msg/octomap.hpp>
 #include <octomap_msgs/srv/get_octomap.hpp>
 #include <octomap_msgs/srv/bounding_box_query.hpp>


### PR DESCRIPTION
<!--
- Please fill the sections below and the PR metadata.
- Make it readable for reviewers and future visitors.
-->

### Description
<!--- Describe your changes in detail -->
This PR fixed the build error.

Files changed.
* Warning removed ( renamed .h to .hpp ) in the header file.
* Fixed error ( conversions.h not found)
  * This is changed in earlier [PR](https://github.com/DeepX-inc/octomap_server2/commit/482d7343b85389ffc72f5e5898314ef1077c641c) somehow.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested?
<!--- Help reviewers by providing explanations, code snippets, checklists, etc. -->

```bash

mkdir -p ~/test_ws/src/
cd ~/test_ws/src/
git clone git@github.com:DeepX-inc/octomap_server2.git -b fix/build

# Clone dependencies
git clone https://github.com/OctoMap/octomap_msgs.git -b ros2
git clone https://github.com/ros-perception/perception_pcl.git -b ros2
git clone https://github.com/ros-perception/pcl_msgs.git -b 1.0.0

docker run --name test_system -dt --rm -v ~/test_ws/src:/root/deepx_ws/src "ghcr.io/deepx-inc/faro:system-base"

docker exec -it test_system bash
pip3 install setuptools==58.2.0
cd /root/deepx_ws/
colcon build --packages-up-to octomap_server2

exit

docker stop test_system


```

---

- [PR Guidelines](https://github.com/DeepX-inc/.github/blob/main/pull_request_guidelines.md)