### PR TITLE
Silence periodic debug logs

### DIFF
--- a/src/octomap_server.cpp
+++ b/src/octomap_server.cpp
@@ -384,7 +384,7 @@ namespace octomap_server {
 
         auto end = std::chrono::steady_clock::now();
         std::chrono::duration<double> elapsed_seconds = end - start;
-        RCLCPP_INFO(this->get_logger(), "Time lapse %f", elapsed_seconds.count());
+        RCLCPP_DEBUG(this->get_logger(), "Time lapse %f", elapsed_seconds.count());
         
         publishAll(cloud->header.stamp);
     }
@@ -478,7 +478,7 @@ namespace octomap_server {
 
         auto end = std::chrono::steady_clock::now();
         std::chrono::duration<double> elapsed_seconds = end - start;
-        RCLCPP_INFO(this->get_logger(), "Time lapse[insert] %f", elapsed_seconds.count());
+        RCLCPP_DEBUG(this->get_logger(), "Time lapse[insert] %f", elapsed_seconds.count());
         
         // mark free cells only if not seen occupied in this cloud
         for(auto it = free_cells.begin(), end=free_cells.end();


### PR DESCRIPTION
### Description
Silence periodic debug logs.
- Convert them to DEBUG logs instead of INFO logs.
- These logs will still be available and recorded in the /rosout topic, but not dumped into the log files.

### Motivation and Context

These logs are displayed for every perception spin (e.g. 10Hz), making all other logs unreadable.

Example logs for every spin:
```
1704824061.0892236 [octomap_server-5] [0m[INFO] [1704824061.088726474]  Time lapse[insert] 0.222986[0m
1704824061.1180499 [octomap_server-5] [0m[INFO] [1704824061.117540878]  Time lapse 0.253944[0m
```

### How Has This Been Tested?

Built the octomap server and executed the perception pipeline. No periodic logs were displayed in the terminal or log files.
