### PR TITLE
Add missing heartbeat publication

### DIFF
--- a/include/octomap_server2/octomap_server.hpp
+++ b/include/octomap_server2/octomap_server.hpp
@@ -93,6 +93,8 @@ namespace octomap_server {
                           >::SharedPtr m_fullMapPub;
         rclcpp::Publisher<nav_msgs::msg::OccupancyGrid
                           >::SharedPtr m_mapPub;
+        rclcpp::Publisher<std_msgs::msg::Header
+                          >::SharedPtr m_heartbeatPub;
         
         rclcpp::Service<OctomapSrv>::SharedPtr m_octomapBinaryService;
         rclcpp::Service<OctomapSrv>::SharedPtr m_octomapFullService;

--- a/src/octomap_server.cpp
+++ b/src/octomap_server.cpp
@@ -186,6 +186,9 @@ namespace octomap_server {
         this->m_fmarkerPub = this->create_publisher<
             visualization_msgs::msg::MarkerArray>(
                 "free_cells_vis_array", qos);
+        this->m_heartbeatPub = this->create_publisher<
+            std_msgs::msg::Header>(
+                "~/heartbeat", qos);
     }
 
     void OctomapServer::subscribe() {
@@ -279,7 +282,11 @@ namespace octomap_server {
     void OctomapServer::insertCloudCallback(
         const sensor_msgs::msg::PointCloud2::ConstSharedPtr &cloud){
         auto start = std::chrono::steady_clock::now();
-        
+        // Publish the heartbeat
+        auto heartbeat_msg = std_msgs::msg::Header();
+        heartbeat_msg.stamp = this->get_clock()->now();
+        this->m_heartbeatPub->publish(heartbeat_msg);
+
         //
         // ground filtering in base frame
         //


### PR DESCRIPTION
### Description

Cherry-pick the [heartbeat commit](https://github.com/DeepX-inc/octomap_server2/commit/f05cf140a04bedc38aa954cd5e5121ecd0671615) from `master` to the `humble` branch.

### Motivation and Context

After the humble migration, the octomap does not publish heartbeats anymore.

This issue affects the integration with the watchdog component, which kills the octomap_server node every 30 seconds:
```
1705568339.9261062 [watchdog_node-11] [ERROR] [1705568339.925697722] [excavator2.system.watchdog]: Cannot receive perception/octomap_server2's first heartbeat more than 30.000000s. Sent kill signal!
```

Comparison based on [the relevant commit diff](https://github.com/DeepX-inc/prj_oliver/pull/769/files#diff-7f157a1b016091fd0fb0afca11d345a737224f36243981369618b2c81baaead6L25):
- Before: Locked to v0.0.2, which contains [the heartbeat commit](https://github.com/DeepX-inc/octomap_server2/commit/f05cf140a04bedc38aa954cd5e5121ecd0671615).
- Now, locked to the [humble branch](https://github.com/DeepX-inc/octomap_server2/commits/humble/), which does not contain the commit.

### How Has This Been Tested?

- [x] Verify the octomap server publishes heartbeats in E2E.


<br>
---

- [DeepX PR Guidelines](https://github.com/DeepX-inc/.github/blob/main/pull_request_guidelines.md) - for descriptions and metadata.
- [Google Code Review Guidelines](https://google.github.io/eng-practices/) - for [authors](https://google.github.io/eng-practices/review/developer/) and [reviewers](https://google.github.io/eng-practices/review/reviewer/).
- [Semantic Code Reviews](https://www.m31coding.com/blog/semantic-reviews.html) - Simple and direct comments without drama.
