### PR TITLE
Disable parameter services

### DIFF
--- a/src/octomap_server.cpp
+++ b/src/octomap_server.cpp
@@ -5,7 +5,9 @@ namespace octomap_server {
     OctomapServer::OctomapServer(
         const rclcpp::NodeOptions &options,
         const std::string node_name):
-        Node(node_name, options),
+        Node(
+            node_name,
+            rclcpp::NodeOptions(options).start_parameter_services(false)),
         m_octree(NULL),
         m_maxRange(20),
         m_worldFrameId("/map"),


### PR DESCRIPTION
### Description

Disable ROS Node parameter services.

### Motivation and Context

Mitigate network strain because of DDS discovery over WiFi.

The following services are suppressed now:
- `~/describe_parameters`
- `~/get_parameter_types`
- `~/get_parameters`
- `~/list_parameters`
- `~/set_parameters`
- `~/set_parameters_atomically`

The services are not needed.

### How Has This Been Tested?

Locally.

```bash
colcon build --packages-select octomap_server2
ros2 launch octomap_server2 octomap_server_launch.py
ros2 service list
```


<br>
---

- [DeepX PR Guidelines](https://github.com/DeepX-inc/.github/blob/main/pull_request_guidelines.md) - for descriptions and metadata.
- [Google Code Review Guidelines](https://google.github.io/eng-practices/) - for [authors](https://google.github.io/eng-practices/review/developer/) and [reviewers](https://google.github.io/eng-practices/review/reviewer/).
- [Semantic Code Reviews](https://www.m31coding.com/blog/semantic-reviews.html) - Simple and direct comments without drama.
