### PR TITLE
Add health metrics for in/out PCD topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ ros2 launch octomap_server2 octomap_server_launch.py
    3. Publication period can be configured with the `heartbeat_period_ms` parameter.
 4. [Disable parameter services (#8)](https://github.com/DeepX-inc/octomap_server2/commit/cef67a4cba0baf1cdedd5c7c297c52c0c8b41428): To mitigate network load due to DDS discovery over WiFi.
 5. [Add health metrics for in/out PCD topics #10](https://github.com/DeepX-inc/octomap_server2/pull/10):
-   1. Add `~/health/cloud_in` publisher: Signal that the `cloud_in` callback has been triggered.
-   2. Add `~/health/cloud_out` publisher: Signal that `octomap_point_cloud_centers` has been published.
+   1. Add `~/health/cloud_received` publisher: Signal that the `cloud_in` callback has been triggered.
+   2. Add `~/health/cloud_published` publisher: Signal that `octomap_point_cloud_centers` has been published.
    3. Add `publish_health_metrics` boolean parameter (default: `false`).
    4. Message type: [std_msgs::Header](https://docs.ros2.org/latest/api/std_msgs/msg/Header.html) (`frame_id` field is not used).

--- a/README.md
+++ b/README.md
@@ -30,3 +30,18 @@ Launch the node with appropriate input on topic `cloud_in`
 ```bash
 $ ros2 launch octomap_server2 octomap_server_launch.py
 ```
+
+## Changelog by DeepX
+
+1. Several PRs to make the fork work on ROS 2.
+2. [Silence periodic debug logs (#6)](https://github.com/DeepX-inc/octomap_server2/commit/854f2cd7c14e5094ad1cbd76adb5de28303f0de9): Convert periodic spam logs to use DEBUG level.
+3. Add `~/heartbeat` publisher ([4739b33](https://github.com/DeepX-inc/octomap_server2/commit/4739b33deab7f781bbf4c94c85c6d75c2952e628), [e1ab37d](https://github.com/DeepX-inc/octomap_server2/commit/e1ab37db151275027835698af499e72d3b214641)).
+   1. Message type: [std_msgs::Header](https://docs.ros2.org/latest/api/std_msgs/msg/Header.html) (`frame_id` field is not used).
+   2. Published periodically at 10 Hz (default).
+   3. Publication period can be configured with the `heartbeat_period_ms` parameter.
+4. [Disable parameter services (#8)](https://github.com/DeepX-inc/octomap_server2/commit/cef67a4cba0baf1cdedd5c7c297c52c0c8b41428): To mitigate network load due to DDS discovery over WiFi.
+5. [Add health metrics for in/out PCD topics #10](https://github.com/DeepX-inc/octomap_server2/pull/10):
+   1. Add `~/health/cloud_in` publisher: Signal that the `cloud_in` callback has been triggered.
+   2. Add `~/health/cloud_out` publisher: Signal that `octomap_point_cloud_centers` has been published.
+   3. Add `publish_health_metrics` boolean parameter (default: `false`).
+   4. Message type: [std_msgs::Header](https://docs.ros2.org/latest/api/std_msgs/msg/Header.html) (`frame_id` field is not used).

--- a/include/octomap_server2/octomap_server.hpp
+++ b/include/octomap_server2/octomap_server.hpp
@@ -96,9 +96,9 @@ namespace octomap_server {
         rclcpp::Publisher<std_msgs::msg::Header
                           >::SharedPtr m_heartbeatPub;
         rclcpp::Publisher<std_msgs::msg::Header
-                          >::SharedPtr m_cloudInHealthPub;
+                          >::SharedPtr m_cloudReceivedHealthPub;
         rclcpp::Publisher<std_msgs::msg::Header
-                          >::SharedPtr m_cloudOutHealthPub;
+                          >::SharedPtr m_cloudPublishedHealthPub;
         rclcpp::TimerBase::SharedPtr heartbeat_timer_;
 
         rclcpp::Service<OctomapSrv>::SharedPtr m_octomapBinaryService;

--- a/include/octomap_server2/octomap_server.hpp
+++ b/include/octomap_server2/octomap_server.hpp
@@ -95,6 +95,10 @@ namespace octomap_server {
                           >::SharedPtr m_mapPub;
         rclcpp::Publisher<std_msgs::msg::Header
                           >::SharedPtr m_heartbeatPub;
+        rclcpp::Publisher<std_msgs::msg::Header
+                          >::SharedPtr m_cloudInHealthPub;
+        rclcpp::Publisher<std_msgs::msg::Header
+                          >::SharedPtr m_cloudOutHealthPub;
         rclcpp::TimerBase::SharedPtr heartbeat_timer_;
 
         rclcpp::Service<OctomapSrv>::SharedPtr m_octomapBinaryService;
@@ -138,6 +142,7 @@ namespace octomap_server {
         double m_groundFilterAngle;
         double m_groundFilterPlaneDistance;
         bool m_compressMap;
+        bool m_publishHealthMetrics{false};
         std::chrono::milliseconds heartbeat_period_ms_;
 
         // downprojected 2D map:

--- a/src/octomap_server.cpp
+++ b/src/octomap_server.cpp
@@ -195,10 +195,10 @@ namespace octomap_server {
                 "free_cells_vis_array", qos);
         this->m_heartbeatPub = this->create_publisher<
             std_msgs::msg::Header>("~/heartbeat", qos);
-        this->m_cloudInHealthPub = this->create_publisher<
-            std_msgs::msg::Header>("~/health/cloud_in", qos);
-        this->m_cloudOutHealthPub = this->create_publisher<
-            std_msgs::msg::Header>("~/health/cloud_out", qos);
+        this->m_cloudReceivedHealthPub = this->create_publisher<
+            std_msgs::msg::Header>("~/health/cloud_received", qos);
+        this->m_cloudPublishedHealthPub = this->create_publisher<
+            std_msgs::msg::Header>("~/health/cloud_published", qos);
     }
 
     void OctomapServer::subscribe() {
@@ -301,7 +301,7 @@ namespace octomap_server {
         if (m_publishHealthMetrics) {
             std_msgs::msg::Header health;
             health.stamp = this->get_clock()->now();
-            this->m_cloudInHealthPub->publish(health);
+            this->m_cloudReceivedHealthPub->publish(health);
         }
 
         //
@@ -794,7 +794,7 @@ namespace octomap_server {
                 // any unexpected delay in this function.
                 std_msgs::msg::Header health;
                 health.stamp = this->get_clock()->now();
-                m_cloudOutHealthPub->publish(health);
+                m_cloudPublishedHealthPub->publish(health);
             }
         }
 

--- a/src/octomap_server.cpp
+++ b/src/octomap_server.cpp
@@ -157,6 +157,9 @@ namespace octomap_server {
         m_publishFreeSpace = this->declare_parameter(
             "publish_free_space", m_publishFreeSpace);
 
+        m_publishHealthMetrics = this->declare_parameter(
+            "publish_health_metrics", m_publishHealthMetrics);
+
         RCLCPP_INFO(this->get_logger(),
             "Publishing non-latched (topics are only"
             " prepared as needed, will only be re-published on map change");
@@ -191,8 +194,11 @@ namespace octomap_server {
             visualization_msgs::msg::MarkerArray>(
                 "free_cells_vis_array", qos);
         this->m_heartbeatPub = this->create_publisher<
-            std_msgs::msg::Header>(
-                "~/heartbeat", qos);
+            std_msgs::msg::Header>("~/heartbeat", qos);
+        this->m_cloudInHealthPub = this->create_publisher<
+            std_msgs::msg::Header>("~/health/cloud_in", qos);
+        this->m_cloudOutHealthPub = this->create_publisher<
+            std_msgs::msg::Header>("~/health/cloud_out", qos);
     }
 
     void OctomapServer::subscribe() {
@@ -290,6 +296,13 @@ namespace octomap_server {
     void OctomapServer::insertCloudCallback(
         const sensor_msgs::msg::PointCloud2::ConstSharedPtr &cloud){
         auto start = std::chrono::steady_clock::now();
+
+        // Use ROS Time instead of Wall Time.
+        if (m_publishHealthMetrics) {
+            std_msgs::msg::Header health;
+            health.stamp = this->get_clock()->now();
+            this->m_cloudInHealthPub->publish(health);
+        }
 
         //
         // ground filtering in base frame
@@ -775,6 +788,14 @@ namespace octomap_server {
             cloud.header.frame_id = m_worldFrameId;
             cloud.header.stamp = rostime;
             m_pointCloudPub->publish(cloud);
+
+            if (m_publishHealthMetrics) {
+                // Use the latest 'now' in case there is
+                // any unexpected delay in this function.
+                std_msgs::msg::Header health;
+                health.stamp = this->get_clock()->now();
+                m_cloudOutHealthPub->publish(health);
+            }
         }
 
         if (publishBinaryMap) {


### PR DESCRIPTION
### Description

Add std_msgs::Header publishers to signal whenever a point cloud is received or published.
- Add publisher "~/health/cloud_received" to signal that the "cloud_in" callback has been triggered.
- Add publisher "~/health/cloud_published" to signal that "octomap_point_cloud_centers" has been published.
- Add `publish_health_metrics` boolean parameter (disabled by default).

This PR implements a simpler version of the health metrics tool added in https://github.com/DeepX-inc/prj_oliver/pull/1166.
- Because I prefer to minimize the changes to this fork.
- Because publishing the stamp is enough:
  - The frequency can be derived during post-processing by comparing the stamps.
  - The message size and throughput should match the metrics published for the cloud_in/out counterpart topics.

### Motivation and Context

Related to [this ClickUp task](https://app.clickup.com/t/86enyaf4g).

### How Has This Been Tested?

Locally.

```bash
colcon build --packages-select octomap_server2
ros2 launch octomap_server2 octomap_server_launch.py

# Show the new topics are exposed
ros2 topic list | grep health

# but these won't show anything because there is no input cloud.
ros2 topic echo /octomap_server/health/cloud_received
ros2 topic echo /octomap_server/health/cloud_published
```

For testing with actual values, I used the simulated system:
- Tested with `publish_health_metrics` set to false and true.
- By launching the full system in simulation, the `ros2 topic echo` calls will show updates.
- Will add details in the related PR in the project repo (to not expose details here).

<br>
---

- [DeepX PR Guidelines](https://github.com/DeepX-inc/.github/blob/main/pull_request_guidelines.md) - for descriptions and metadata.
- [Google Code Review Guidelines](https://google.github.io/eng-practices/) - for [authors](https://google.github.io/eng-practices/review/developer/) and [reviewers](https://google.github.io/eng-practices/review/reviewer/).
- [Semantic Code Reviews](https://www.m31coding.com/blog/semantic-reviews.html) - Simple and direct comments without drama.